### PR TITLE
utils: Use native RSA generation crypto library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,11 +139,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
-    "keypair": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
-      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "chai": "^4.2.0",
     "jsbn": "^1.1.0",
-    "keypair": "^1.0.1",
     "mocha": "^5.2.0"
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,6 @@
 "use strict";
 
 let crypto = require('crypto');
-var keypair = require('keypair');
 
 // CRYPTO settings
 const HASH_ALG = 'sha256';
@@ -13,7 +12,21 @@ exports.hash = function hash(s, encoding) {
 }
 
 exports.generateKeypair = function() {
-  return keypair();
+  const kp = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+      publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem'
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem'
+      }
+  });
+  return {
+    public: kp.publicKey,
+    private: kp.privateKey,
+  };
 }
 
 exports.sign = function(privKey, msg) {

--- a/utils.js
+++ b/utils.js
@@ -13,7 +13,7 @@ exports.hash = function hash(s, encoding) {
 
 exports.generateKeypair = function() {
   const kp = crypto.generateKeyPairSync('rsa', {
-    modulusLength: 2048,
+    modulusLength: 512,
       publicKeyEncoding: {
         type: 'spki',
         format: 'pem'


### PR DESCRIPTION
Drops key generation time from 4000ms to 4ms on my laptop.

Requires Node.js v10.12.0, released October 2018.

- Driver run time decreases from 20 seconds to 5 seconds.
- Test run time decreases from 10 seconds to 0.5 seconds.