### PR TITLE
driver: Use process.exit to quit

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -86,5 +86,5 @@ setTimeout(() => {
   console.log("Final balances (Donald's perspective):");
   showBalances(donald);
 
-  throw "TERMINATE";
+  process.exit(0);
 }, 5000);


### PR DESCRIPTION
Cleanly exit driver process with `process.exit()`.