### PR TITLE
Use native BigInt

### DIFF
--- a/block.js
+++ b/block.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const BigInteger = require('jsbn').BigInteger;
-
 const Blockchain = require('./blockchain.js');
 
 const utils = require('./utils.js');
@@ -15,7 +13,7 @@ module.exports = class Block {
   /**
    * Creates a new Block.  Note that the previous block will not be stored;
    * instead, its hash value will be maintained in this block.
-   * 
+   *
    * @constructor
    * @param {String} rewardAddr - The address to receive all mining rewards for this block.
    * @param {Block} [prevBlock] - The previous block in the blockchain.
@@ -68,7 +66,7 @@ module.exports = class Block {
 
   /**
    * Determines whether the block is the beginning of the chain.
-   * 
+   *
    * @returns {Boolean} - True if this is the first block in the chain.
    */
   isGenesisBlock() {
@@ -78,19 +76,19 @@ module.exports = class Block {
   /**
    * Returns true if the hash of the block is less than the target
    * proof of work value.
-   * 
+   *
    * @returns {Boolean} - True if the block has a valid proof.
    */
   hasValidProof() {
     let h = utils.hash(this.serialize());
-    let n = new BigInteger(h, 16);
-    return n.compareTo(this.target) < 0;
+    let n = BigInt(`0x${h}`);
+    return n < this.target;
   }
 
   /**
    * Converts a Block into string form.  Some fields are deliberately omitted.
    * Note that Block.deserialize plus block.rerun should restore the block.
-   * 
+   *
    * @returns {String} - The block in JSON format.
    */
   serialize() {
@@ -157,7 +155,7 @@ module.exports = class Block {
    * Returns the cryptographic hash of the current block.
    * The block is first converted to its serial form, so
    * any unimportant fields are ignored.
-   * 
+   *
    * @returns {String} - cryptographic hash of the block.
    */
   hashVal() {
@@ -166,7 +164,7 @@ module.exports = class Block {
 
   /**
    * Returns the hash of the block as its id.
-   * 
+   *
    * @returns {String} - A unique ID for the block.
    */
   get id() {
@@ -175,10 +173,10 @@ module.exports = class Block {
 
   /**
    * Accepts a new transaction if it is valid and adds it to the block.
-   * 
+   *
    * @param {Transaction} tx - The transaction to add to the block.
    * @param {Client} [client] - A client object, for logging useful messages.
-   * 
+   *
    * @returns {Boolean} - True if the transaction was added successfully.
    */
   addTransaction(tx, client) {
@@ -232,9 +230,9 @@ module.exports = class Block {
    * and re-adding all transactions.  This process also identifies if any transactions were
    * invalid due to insufficient funds or replayed transactions, in which case the block
    * should be rejected.
-   * 
+   *
    * @param {Block} prevBlock - The previous block in the blockchain, used for initial balances.
-   * 
+   *
    * @returns {Boolean} - True if the block's transactions are all valid.
    */
   rerun(prevBlock) {
@@ -262,9 +260,9 @@ module.exports = class Block {
    * Note that this amount is a snapshot in time - IF the block is
    * accepted by the network, ignoring any pending transactions,
    * this is the amount of funds available to the client.
-   * 
+   *
    * @param {String} addr - Address of a client.
-   * 
+   *
    * @returns {Number} - The available gold for the specified user.
    */
   balanceOf(addr) {
@@ -275,9 +273,9 @@ module.exports = class Block {
    * The total amount of gold paid to the miner who produced this block,
    * if the block is accepted.  This includes both the coinbase transaction
    * and any transaction fees.
-   * 
+   *
    * @returns {Number} Total reward in gold for the user.
-   * 
+   *
    */
   totalRewards() {
     return [...this.transactions].reduce(

--- a/blockchain.js
+++ b/blockchain.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const BigInteger = require('jsbn').BigInteger;
-
 // Network message constants
 const MISSING_BLOCK = "MISSING_BLOCK";
 const POST_TRANSACTION = "POST_TRANSACTION";
@@ -12,8 +10,8 @@ const START_MINING = "START_MINING";
 const NUM_ROUNDS_MINING = 2000;
 
 // Constants related to proof-of-work target
-const POW_BASE_TARGET = new BigInteger("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
-const POW_LEADING_ZEROES = 15;
+const POW_BASE_TARGET = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+const POW_LEADING_ZEROES = 15n;
 
 // Constants for mining rewards and default transaction fees
 const COINBASE_AMT_ALLOWED = 25;
@@ -48,23 +46,23 @@ module.exports = class Blockchain {
    * Produces a new genesis block, giving the specified clients
    * the specified amount of starting gold.  Either clientBalanceMap
    * OR startingBalances can be specified, but not both.
-   * 
+   *
    * If clientBalanceMap is specified, then this method will also
    * set the genesis block for every client passed in.  This option
    * is useful in single-threaded mode.
-   * 
+   *
    * @param {Object} cfg - Settings for the blockchain.
    * @param {Class} cfg.blockClass - Implementation of the Block class.
    * @param {Class} cfg.transactionClass - Implementation of the Transaction class.
    * @param {Map} [cfg.clientBalanceMap] - Mapping of clients to their starting balances.
    * @param {Object} [cfg.startingBalances] - Mapping of client addresses to their starting balances.
-   * @param {number} [cfg.powLeadingZeroes] - Number of leading zeroes required for a valid proof-of-work.
+   * @param {BigInt} [cfg.powLeadingZeroes] - Number of leading zeroes required for a valid proof-of-work.
    * @param {number} [cfg.coinbaseAmount] - Amount of gold awarded to a miner for creating a block.
    * @param {number} [cfg.defaultTxFee] - Amount of gold awarded to a miner for accepting a transaction,
    *    if not overridden by the client.
    * @param {number} [cfg.confirmedDepth] - Number of blocks required after a block before it is
    *    considered confirmed.
-   * 
+   *
    * @returns {Block} - The genesis block.
    */
   static makeGenesis({
@@ -84,8 +82,8 @@ module.exports = class Blockchain {
 
     // Setting blockchain configuration
     Blockchain.cfg = { blockClass, transactionClass, coinbaseAmount, defaultTxFee, confirmedDepth };
-    Blockchain.cfg.powTarget = POW_BASE_TARGET.shiftRight(powLeadingZeroes);
-    
+    Blockchain.cfg.powTarget = POW_BASE_TARGET >> powLeadingZeroes;
+
     // If startingBalances was specified, we initialize our balances to that object.
     let balances = startingBalances || {};
 
@@ -115,9 +113,9 @@ module.exports = class Blockchain {
 
   /**
    * Converts a string representation of a block to a new Block instance.
-   * 
+   *
    * @param {Object} o - An object representing a block, but not necessarily an instance of Block.
-   * 
+   *
    * @returns {Block}
    */
   static deserializeBlock(o) {
@@ -159,7 +157,7 @@ module.exports = class Blockchain {
     } else {
       return new Blockchain.cfg.transactionClass(o);
     }
-    
+
   }
 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spartan-gold",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -732,11 +732,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/taustin/spartan-gold#readme",
   "dependencies": {
     "chai": "^4.2.0",
-    "jsbn": "^1.1.0",
     "mocha": "^5.2.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const assert = require('chai').assert;
-const BigInteger = require('jsbn').BigInteger;
 
 const utils = require('./utils.js');
 
@@ -16,7 +15,7 @@ const kp = utils.generateKeypair();
 let addr = utils.calcAddress(kp.public);
 
 // Adding a POW target that should be trivial to match.
-const EASY_POW_TARGET = new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+const EASY_POW_TARGET = BigInt("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 // Setting blockchain configuration.  (Usually this would be done during the creation of the genesis block.)
 Blockchain.makeGenesis({ blockClass: Block, transactionClass: Transaction });


### PR DESCRIPTION
This PR switches from using the `jsbn` library to using the [`bigint` primitive](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#bigint_type), removing a dependency in the process.

It is purely refactoring and there are no logic changes.

`npm test` seems to still run fine.