### PR TITLE
Run linter in GitHub Actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,12 @@
 {
   "env": {
     "commonjs": true,
-    "es6": true,
+    "es2020": true,
     "mocha": true,
     "node": true
   },
   "extends": "eslint:recommended",
   "globals": {
-  },
-  "parserOptions": {
-    "ecmaVersion": 2018
   },
   "rules": {
     "no-console": 0,

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run build --if-present
+    - run: npm run lint
     - run: npm test
       env:
         CI: true

--- a/blockchain.js
+++ b/blockchain.js
@@ -11,7 +11,7 @@ const NUM_ROUNDS_MINING = 2000;
 
 // Constants related to proof-of-work target
 const POW_BASE_TARGET = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-const POW_LEADING_ZEROES = 15n;
+const POW_LEADING_ZEROES = 15;
 
 // Constants for mining rewards and default transaction fees
 const COINBASE_AMT_ALLOWED = 25;
@@ -56,7 +56,7 @@ module.exports = class Blockchain {
    * @param {Class} cfg.transactionClass - Implementation of the Transaction class.
    * @param {Map} [cfg.clientBalanceMap] - Mapping of clients to their starting balances.
    * @param {Object} [cfg.startingBalances] - Mapping of client addresses to their starting balances.
-   * @param {BigInt} [cfg.powLeadingZeroes] - Number of leading zeroes required for a valid proof-of-work.
+   * @param {number} [cfg.powLeadingZeroes] - Number of leading zeroes required for a valid proof-of-work.
    * @param {number} [cfg.coinbaseAmount] - Amount of gold awarded to a miner for creating a block.
    * @param {number} [cfg.defaultTxFee] - Amount of gold awarded to a miner for accepting a transaction,
    *    if not overridden by the client.
@@ -82,7 +82,7 @@ module.exports = class Blockchain {
 
     // Setting blockchain configuration
     Blockchain.cfg = { blockClass, transactionClass, coinbaseAmount, defaultTxFee, confirmedDepth };
-    Blockchain.cfg.powTarget = POW_BASE_TARGET >> powLeadingZeroes;
+    Blockchain.cfg.powTarget = POW_BASE_TARGET >> BigInt(powLeadingZeroes);
 
     // If startingBalances was specified, we initialize our balances to that object.
     let balances = startingBalances || {};


### PR DESCRIPTION
This PR will (hopefully!) run the linter on push, to protect against things like the lint error from #26 being introduced in the future.

This PR is based on top of the commits from PR #29 so it does not itself fail the lint check!